### PR TITLE
Update documentation around messaging and rights

### DIFF
--- a/sdr/concepts_and_interactions.md
+++ b/sdr/concepts_and_interactions.md
@@ -39,19 +39,19 @@ _TODO: link to code or brief explanation of gbooks accessioning_
 _TODO: link to code or brief explanation of was-registrar-app accessioning_
 
 ## cocina-models
-_SDR data model written as syntactically validatable with dry-struct, dry-types and openapi_
+_SDR data model written as syntactically validatable with dry-struct, dry-types, and openapi_
 
 (ask JCoyne or JLitt)
 
 ## Workflows and Robots
 
-Robots are what we call our individual accessioning processing steps which are grouped into "workflows", coordinated by the workflow server (and Resque and resque-pool).  They do things like updating the SDR metadata store (currently Fedora data streams), generating technical metadata, handing off to the preservation system a copy of each object version, etc.
+Robots are what we call our individual processing steps which are grouped into "workflows", coordinated by the workflow server (and Resque and resque-pool). They do things like updating the SDR metadata store (currently Fedora data streams), generating technical metadata, handing off to the preservation system a copy of each object version, etc.
 
 Together, workflow server and the robots provide a system for managing the SDR accessioning pipeline: the robots ingest content into the SDR; workflow server coordinates by queuing tasks to a shared Redis instance.
 
-The robots inherit their worker functionality from [the lybercore gem](https://github.com/sul-dlss/lyber-core/).
+The robots inherit their worker functionality from [the lyber-core gem](https://github.com/sul-dlss/lyber-core/).
 
-Each type of robot has one or more VMs of its own, but all share the same Redis instance, and all are managed on their respective VMs by resque-pool.
+Each type of robot-suite has one or more VMs of its own, but all share the same Redis instance, and all are managed on their respective VMs by resque-pool.
 
 This architecture was chosen before open source workflow automation tools like Airflow were available/mature.
 
@@ -59,25 +59,20 @@ Another thing that adds indirection/confusion: sometimes the robots will perform
 
 (ask anyone and hand waving will occur.  Perhaps Peter? Andrew? Naomi? JCoyne? - we can re-figure out the layers of legacy code as a team)
 
-
 ## Access Rights for digital content
 
 (ask JCoyne, John)
 
 * What's an APO?
-* Where are access restrictions computed when interacting with a specific object? - various codebases use the logic provided by the dor-rights-auth gem:  https://github.com/sul-dlss/dor-rights-auth
 * How are they stored? - Currently, in the `rightsMetadata` datastream for an object (an XML datstream stored in Fedora for a druid).  Will be migrated to the Cocina data model and its JSON serialization format.
 * How do they work to restrict access?
   * Defaults are applied based on the item's parent APO
-  * An item can have multiple files, and those files may each have different rights specified from each other as well as from the parent item.  If they don't have rights specified individually, they inherit from the parent item.
+  * An item can have multiple files, and those files may each have different rights specified from each other as well as from the parent item.
 * See also
   * [Rights metadata and public access to SDR objects](https://consul.stanford.edu/display/SDRdocs/Rights+metadata+and+public+access+to+SDR+objects)
-  * [Rights metadata -- the rightsMetadata datastream](https://consul.stanford.edu/display/chimera/Rights+metadata+--+the+rightsMetadata+datastream)
   * [Argo - Editing the license and rights statements for a set of objects](https://consul.stanford.edu/display/DLSSDOCS/Argo+-+Editing+the+license+and+rights+statements+for+a+set+of+objects)
 
 ## Embargoes
-
-(ask JCoyne)
 
 * Part of the cocina-model. They are expired by DSA - it emits a RabbitMQ message.
 * See integration test for ETD

--- a/sdr/messages.md
+++ b/sdr/messages.md
@@ -1,23 +1,32 @@
 # Messages
 
-The SDR passes RabbitMQ messages for the following use cases:
+Use of messages within SDR are detailed herein.
 
-* [H2](/sdr#H2) is notified when an item is registered
-* [H2](/sdr#H2) is notified when an item is deposited
-* [H2](/sdr#H2) is notified when an embargo is lifted
-* [dor-indexing-app](index#dor-indexing-app) is notified when an item needs to be indexed or when it has been deleted
+## Publishers
 
-These messages are produced by:
+* [dor-services-app](/sdr#dor-services-app) publishes messages to
+  * the `sdr.objects.created` topic [when an item is created](https://github.com/sul-dlss/dor-services-app/blob/main/app/services/notifications/object_created.rb)
+  * the `sdr.objects.updated` topic [when an item is updated](https://github.com/sul-dlss/dor-services-app/blob/main/app/services/notifications/object_updated.rb)
+  * the `sdr.objects.deleted` topic [when an item is deleted](https://github.com/sul-dlss/dor-services-app/blob/main/app/services/notifications/object_deleted.rb)
+  * the `sdr.objects.embargo_lifted` topic [when an embargo is lifted](https://github.com/sul-dlss/dor-services-app/blob/main/app/services/notifications/embargo_lifted.rb)
+  * the `sdr.objects.event` topic
+* [workflow-server-rails](/sdr#workflow-server) publishes messages to the `sdr.workflow` topic [when an workflow step changes state](https://github.com/sul-dlss/workflow-server-rails/blob/main/app/services/send_rabbitmq_message.rb)
+* [preservation_catalog](/sdr#preservation-catalog) publishes messages to the `sdr.objects.event` topic [when a druid version is replicated](https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/results_recorder_job.rb), and [when preservation audits complete (whether success or failure)](https://github.com/sul-dlss/preservation_catalog/blob/main/app/services/reporters/event_service_reporter.rb).
 
-* [dor-services-app](/sdr#dor-services-app)  sends messages when an item is updated: https://github.com/sul-dlss/dor-services-app/blob/e8d7595f96c62b8b4a7c13a98618c2c66a521504/app/services/notifications/object_updated.rb
-* [dor-services-app](/sdr#dor-services-app) sends messages when an embargo is lifted: https://github.com/sul-dlss/dor-services-app/blob/604a041dbb8d19735ee1fcd6fc0445ff614e5593/app/services/embargo_release_service.rb#L55
-* [workflow-server-rails](/sdr#workflow-server) sends messages when an workflow step changes state: https://github.com/sul-dlss/workflow-server-rails/blob/e328f768446aa37dcd067d830f9833c7c4f36c57/app/services/send_update_message.rb#L9
+## Topics
 
-The topics are:
+* `sdr.workflow` is used for workflow transitions.  The routing key is composed of the step name and status, which for example allows subscribers to bind to `end-accession.completed` in order to know when an item has finished accessioning.
+* `sdr.objects.created` is used for newly created (registered) objects. The routing key is the project tag. This enables subscribers to filter messages pertaining to specific projects (e.g., "h2").
+* `sdr.objects.updated` is used for updated objects. The routing key is the first project tag for items and collections or the string `SDR` for administrative policies. This enables subscribers to filter messages pertaining to specific projects (e.g., "h2").
+* `sdr.objects.deleted` is used for deleted objects. The routing key is the first project tag for items and collections or the string `SDR` for administrative policies. This enables subscribers to filter messages pertaining to specific projects (e.g., "h2").
+* `sdr.embargo_lifted` is used for an embargo that is lifted. The routing key is the first project tag for items and collections or the string `SDR` for administrative policies. This enables subscribers to filter messages pertaining to specific projects (e.g., "h2").
+* `sdr.objects.event` is used for recording events. The routing key is the event type.
 
-* `sdr.workflow` for workflow transitions.  The routing key is composed of the step name and status, which allows consumers to bind to: `end-accession.completed` in order to know when an item has been deposited.
-* `sdr.objects.created` for newly created (registered) objects. The routing key is the project tag.  This enables consumers to filter just the objets affiliated with specific projects (e.g. "h2")
-* `sdr.embargo_lifted` for an embargo that is lifted. The routing key is the project tag.  This enables consumers to filter just the objets affiliated with specific projects (e.g. "h2")
+## Subscribers
 
-The binding of queues to topics happens in H2 by running this rake task:
+* [H2](/sdr#H2) subscribes to the `sdr.workflow`, `sdr.objects.embargo_lifted`, and `sdr.objects.created` topics
+* [dor-indexing-app](index#dor-indexing-app) subscribes to the `sdr.workflow`, `sdr.objects.updated`, `sdr.objects.deleted`, and `sdr.objects.created` topics
+* [dor-services-app](/sdr#dor-services-app) subscribes to the `sdr.objects.event` topic
+
+Subscribers bind queues to topics in order to asynchronously act on messages, and said binding happens in SDR apps by running a dedicated rake task, e.g.:
 https://github.com/sul-dlss/happy-heron/blob/main/lib/tasks/rabbitmq.rake


### PR DESCRIPTION
Fixes #7

This commit updates our team documentation with a focus on removing the reference to the `dor-rights-auth` gem which our portfolio no longer uses, and on restructuring and augmenting SDR messaging documentation.
